### PR TITLE
chore: simplify Justfile pipeline recipes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -30,10 +30,14 @@ lint:
 fmt:
     uv run ruff format src/ tests/
 
-# Run the attractor CLI
-run *ARGS:
-    uv run attractor {{ ARGS }}
+# Run a pipeline (e.g. just run discovery)
+run NAME *ARGS:
+    uv run attractor run pipelines/{{ NAME }}.dot {{ ARGS }}
 
-# Validate a pipeline file
-validate PIPELINE:
-    uv run attractor validate {{ PIPELINE }}
+# Run a pipeline with auto-approve (e.g. just yolo discovery)
+yolo NAME *ARGS:
+    just run {{ NAME }} --auto-approve {{ ARGS }}
+
+# Validate a pipeline file (e.g. just validate discovery)
+validate NAME:
+    uv run attractor validate pipelines/{{ NAME }}.dot


### PR DESCRIPTION
## Summary
- Simplify Justfile so pipelines can be run by name (`just run discovery`) instead of full path
- Add `just yolo` shortcut for auto-approved pipeline runs

## Changes
- `just run <name>` now resolves to `pipelines/<name>.dot` automatically
- Added `just yolo <name>` as shorthand for `just run <name> --auto-approve`
- `just validate <name>` also resolves pipeline by name

🤖 Generated with [Claude Code](https://claude.com/claude-code)