### PR TITLE
feat: add run config and CLI flags for goal, repo, and max-steps

### DIFF
--- a/src/attractor/cli.py
+++ b/src/attractor/cli.py
@@ -4,15 +4,40 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import sys
 from pathlib import Path
+from typing import Any
 
 from attractor.pipeline.engine import Engine, EngineError
+from attractor.pipeline.graph import Graph
 from attractor.pipeline.interviewer.auto import AutoApproveInterviewer
 from attractor.pipeline.interviewer.console import ConsoleInterviewer
 from attractor.pipeline.outcome import StageStatus
 from attractor.pipeline.parser import ParseError, parse_dot_file
 from attractor.pipeline.validator import Severity, validate
+
+
+def _load_run_config(config_path: str) -> dict[str, Any]:
+    """Load a JSON run config file."""
+    with open(config_path) as f:
+        return json.load(f)
+
+
+def _merge_run_config(config: dict[str, Any], flags: dict[str, Any]) -> dict[str, Any]:
+    """Merge CLI flags over config — flags with non-None values win."""
+    merged = dict(config)
+    for key, value in flags.items():
+        if value is not None:
+            merged[key] = value
+    return merged
+
+
+def _apply_config_to_graph(graph: Graph, config: dict[str, Any]) -> None:
+    """Apply run config values into graph attrs (config overrides DOT attrs)."""
+    for key, value in config.items():
+        if key != "max_steps":
+            graph.attrs[key] = value
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -28,13 +53,33 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"Parse error: {e}", file=sys.stderr)
         return 1
 
-    interviewer = AutoApproveInterviewer() if args.auto_approve else ConsoleInterviewer()
+    # Build run config: DOT attrs < config file < CLI flags
+    config: dict[str, Any] = {}
+    if args.config:
+        try:
+            config = _load_run_config(args.config)
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"Config error: {e}", file=sys.stderr)
+            return 1
 
-    logs_root = args.logs or f"./logs/{Path(dot_path).stem}"
+    flags = {
+        "goal": args.goal,
+        "repo": args.repo,
+        "max_steps": args.max_steps,
+    }
+    config = _merge_run_config(config, flags)
+    _apply_config_to_graph(graph, config)
+
+    max_steps = config.get("max_steps", 100)
+    auto_approve = config.get("auto_approve", False) or args.auto_approve
+    interviewer = AutoApproveInterviewer() if auto_approve else ConsoleInterviewer()
+
+    logs_root = args.logs or config.get("logs") or f"./logs/{Path(dot_path).stem}"
 
     engine = Engine(
         interviewer=interviewer,
         logs_root=logs_root,
+        max_steps=int(max_steps),
     )
 
     print(f"Running pipeline: {graph.name or dot_path}")
@@ -110,6 +155,24 @@ def main() -> None:
     # Run command
     run_parser = subparsers.add_parser("run", help="Run a pipeline")
     run_parser.add_argument("pipeline", help="Path to the .dot pipeline file")
+    run_parser.add_argument(
+        "--config",
+        help="Path to JSON run config file",
+    )
+    run_parser.add_argument(
+        "--goal",
+        help="Pipeline goal (overrides config and DOT attrs)",
+    )
+    run_parser.add_argument(
+        "--repo",
+        help="Target repository path (overrides config and DOT attrs)",
+    )
+    run_parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=None,
+        help="Maximum engine steps before stopping (default: 100)",
+    )
     run_parser.add_argument(
         "--auto-approve",
         action="store_true",

--- a/src/attractor/pipeline/engine.py
+++ b/src/attractor/pipeline/engine.py
@@ -35,9 +35,11 @@ class Engine:
         interviewer: Interviewer | None = None,
         logs_root: str = "./logs",
         codergen_backend: Any = None,
+        max_steps: int = 100,
     ):
         self._interviewer = interviewer or AutoApproveInterviewer()
         self._logs_root = logs_root
+        self._max_steps = max_steps
 
         if registry:
             self._registry = registry
@@ -109,10 +111,18 @@ class Engine:
         # Create logs directory
         Path(self._logs_root).mkdir(parents=True, exist_ok=True)
 
+        step_count = 0
+
         while True:
             node = current_node
             if node is None:
                 break
+
+            step_count += 1
+            if step_count > self._max_steps:
+                raise EngineError(
+                    f"Pipeline exceeded max steps ({self._max_steps})"
+                )
 
             context.set("current_node", node.id)
 

--- a/src/attractor/pipeline/handlers/core.py
+++ b/src/attractor/pipeline/handlers/core.py
@@ -172,8 +172,9 @@ def _parse_accelerator_key(label: str) -> str:
 
 
 def _expand_variables(text: str, graph: Graph, context: Context) -> str:
-    """Expand $goal variable in text."""
-    text = text.replace("$goal", graph.goal)
+    """Expand $<key> variables from graph attrs."""
+    for key, value in graph.attrs.items():
+        text = text.replace(f"${key}", str(value))
     return text
 
 

--- a/tests/pipeline/test_engine.py
+++ b/tests/pipeline/test_engine.py
@@ -6,7 +6,7 @@ import tempfile
 import pytest
 
 from attractor.pipeline.context import Context
-from attractor.pipeline.engine import Engine
+from attractor.pipeline.engine import Engine, EngineError
 from attractor.pipeline.interviewer.auto import AutoApproveInterviewer
 from attractor.pipeline.interviewer.base import Answer
 from attractor.pipeline.interviewer.queue import QueueInterviewer
@@ -179,3 +179,162 @@ class TestConditionEvaluator:
         assert (
             evaluate_condition("outcome=fail AND last_stage=validate", outcome, context) is False
         )
+
+
+class TestVariableExpansion:
+    @pytest.mark.asyncio
+    async def test_expand_repo_variable(self):
+        graph = parse_dot('''
+            digraph Test {
+                graph [goal="Fix bug", repo="/tmp/my-repo"]
+                start [shape=Mdiamond]
+                exit [shape=Msquare]
+                work [label="Work", prompt="Repo is: $repo"]
+                start -> work -> exit
+            }
+        ''')
+        with tempfile.TemporaryDirectory() as logs:
+            engine = Engine(logs_root=logs)
+            await engine.run(graph)
+
+            with open(os.path.join(logs, "work", "prompt.md")) as f:
+                prompt = f.read()
+            assert "/tmp/my-repo" in prompt
+
+    @pytest.mark.asyncio
+    async def test_expand_custom_variable(self):
+        graph = parse_dot('''
+            digraph Test {
+                graph [goal="Fix bug", author="Alice"]
+                start [shape=Mdiamond]
+                exit [shape=Msquare]
+                work [label="Work", prompt="Author: $author, Goal: $goal"]
+                start -> work -> exit
+            }
+        ''')
+        with tempfile.TemporaryDirectory() as logs:
+            engine = Engine(logs_root=logs)
+            await engine.run(graph)
+
+            with open(os.path.join(logs, "work", "prompt.md")) as f:
+                prompt = f.read()
+            assert "Alice" in prompt
+            assert "Fix bug" in prompt
+
+    @pytest.mark.asyncio
+    async def test_unknown_variable_left_as_is(self):
+        graph = parse_dot('''
+            digraph Test {
+                graph [goal="Fix bug"]
+                start [shape=Mdiamond]
+                exit [shape=Msquare]
+                work [label="Work", prompt="Unknown: $nope"]
+                start -> work -> exit
+            }
+        ''')
+        with tempfile.TemporaryDirectory() as logs:
+            engine = Engine(logs_root=logs)
+            await engine.run(graph)
+
+            with open(os.path.join(logs, "work", "prompt.md")) as f:
+                prompt = f.read()
+            assert "$nope" in prompt
+
+
+class TestMaxSteps:
+    @pytest.mark.asyncio
+    async def test_max_steps_stops_engine(self):
+        """Engine should raise EngineError when max_steps is exceeded."""
+        graph = parse_dot('''
+            digraph Test {
+                graph [goal="Loop forever"]
+                start [shape=Mdiamond]
+                exit [shape=Msquare]
+                a [label="A", prompt="Do A"]
+                b [label="B", prompt="Do B"]
+                start -> a -> b -> a
+                b -> exit [condition="outcome=fail"]
+            }
+        ''')
+        with tempfile.TemporaryDirectory() as logs:
+            engine = Engine(logs_root=logs, max_steps=2)
+            with pytest.raises(EngineError, match="max steps"):
+                await engine.run(graph)
+
+    @pytest.mark.asyncio
+    async def test_max_steps_default_allows_normal_pipeline(self):
+        """Normal pipelines should complete fine with the default max_steps."""
+        graph = parse_dot('''
+            digraph Test {
+                start [shape=Mdiamond]
+                exit [shape=Msquare]
+                work [label="Work", prompt="Do work"]
+                start -> work -> exit
+            }
+        ''')
+        with tempfile.TemporaryDirectory() as logs:
+            engine = Engine(logs_root=logs)
+            outcome = await engine.run(graph)
+            assert outcome.status == StageStatus.SUCCESS
+
+
+class TestConfigLoading:
+    def test_load_config_file(self):
+        import json
+        from attractor.cli import _load_run_config
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"goal": "add CSV export", "repo": "/tmp/repo", "max_steps": 50}, f)
+            f.flush()
+
+            config = _load_run_config(f.name)
+            assert config["goal"] == "add CSV export"
+            assert config["repo"] == "/tmp/repo"
+            assert config["max_steps"] == 50
+
+        os.unlink(f.name)
+
+    def test_flags_override_config(self):
+        import json
+        from attractor.cli import _merge_run_config
+
+        config = {"goal": "from config", "repo": "/config/repo", "max_steps": 50}
+        flags = {"goal": "from flag", "repo": None, "max_steps": None}
+
+        merged = _merge_run_config(config, flags)
+        assert merged["goal"] == "from flag"
+        assert merged["repo"] == "/config/repo"
+        assert merged["max_steps"] == 50
+
+    def test_config_overrides_dot_attrs(self):
+        from attractor.cli import _apply_config_to_graph
+
+        graph = parse_dot('''
+            digraph Test {
+                graph [goal="from DOT"]
+                start [shape=Mdiamond]
+                exit [shape=Msquare]
+                start -> exit
+            }
+        ''')
+        config = {"goal": "from config", "repo": "/tmp/repo"}
+        _apply_config_to_graph(graph, config)
+
+        assert graph.attrs["goal"] == "from config"
+        assert graph.attrs["repo"] == "/tmp/repo"
+
+    def test_empty_config_preserves_dot_attrs(self):
+        from attractor.cli import _apply_config_to_graph
+
+        graph = parse_dot('''
+            digraph Test {
+                graph [goal="from DOT"]
+                start [shape=Mdiamond]
+                exit [shape=Msquare]
+                start -> exit
+            }
+        ''')
+        config: dict = {}
+        _apply_config_to_graph(graph, config)
+
+        assert graph.attrs["goal"] == "from DOT"


### PR DESCRIPTION
## Summary
- Adds `--config`, `--goal`, `--repo`, and `--max-steps` CLI flags with proper precedence: flags > config file > DOT attrs
- Generalizes variable expansion to support any `$<key>` from graph attrs (not just `$goal`)
- Adds `max_steps` safety limit to the engine loop to prevent runaway pipelines

## Changes
- **`src/attractor/cli.py`**: Added `--config` (JSON file), `--goal`, `--repo`, `--max-steps` flags; config loading/merging helpers (`_load_run_config`, `_merge_run_config`, `_apply_config_to_graph`)
- **`src/attractor/pipeline/engine.py`**: Added `max_steps` param to `Engine.__init__()` (default 100); step counter raises `EngineError` when exceeded
- **`src/attractor/pipeline/handlers/core.py`**: Generalized `_expand_variables()` to expand any `$<key>` from graph attrs
- **`tests/pipeline/test_engine.py`**: Added tests for variable expansion (`$repo`, `$author`, unknown vars), max_steps enforcement, config loading, and precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)